### PR TITLE
Dt 963 Build user to offender access profile from scope

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/SecurityUserContext.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/SecurityUserContext.kt
@@ -1,40 +1,16 @@
 package uk.gov.justice.hmpps.offendersearch.config
 
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.offendersearch.security.AuthAwareAuthenticationToken
 
 @Component
 class SecurityUserContext {
-  private val authentication: Authentication
-    get() = SecurityContextHolder.getContext().authentication
+  val authentication: AuthAwareAuthenticationToken?
+    get() = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
 
   val currentUsername: String?
-    get() {
-      val username: String?
-      val userPrincipal = userPrincipal
-      username = when (userPrincipal) {
-        is String -> {
-          userPrincipal
-        }
-        is UserDetails -> {
-          userPrincipal.username
-        }
-        is Map<*, *> -> {
-          userPrincipal["username"] as String?
-        }
-        else -> {
-          null
-        }
-      }
-      return username
-    }
-
-  private val userPrincipal: Any?
-    get() {
-      val auth = authentication
-      return auth.principal
-    }
-
+    get() = authentication?.takeUnless { it.clientOnly }?.subject
+  val currentDeliusUsername: String?
+    get() = authentication?.takeUnless { it.clientOnly }?.takeIf { it.deliusUser }?.subject
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/SecurityUserContext.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/SecurityUserContext.kt
@@ -7,7 +7,12 @@ import uk.gov.justice.hmpps.offendersearch.security.AuthAwareAuthenticationToken
 @Component
 class SecurityUserContext {
   val authentication: AuthAwareAuthenticationToken?
-    get() = SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken
+    get() = with(SecurityContextHolder.getContext().authentication) {
+      when (this) {
+        is AuthAwareAuthenticationToken -> this
+        else -> null
+      }
+    }
 
   val currentUsername: String?
     get() = authentication?.takeUnless { it.clientOnly }?.subject

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
@@ -20,17 +20,19 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.hmpps.offendersearch.BadRequestException
 import uk.gov.justice.hmpps.offendersearch.NotFoundException
+import uk.gov.justice.hmpps.offendersearch.config.SecurityUserContext
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderDetail
 import uk.gov.justice.hmpps.offendersearch.dto.SearchDto
 import uk.gov.justice.hmpps.offendersearch.dto.SearchPhraseFilter
 import uk.gov.justice.hmpps.offendersearch.dto.SearchPhraseResults
+import uk.gov.justice.hmpps.offendersearch.security.getOffenderUserAccessFromScopes
 import uk.gov.justice.hmpps.offendersearch.services.SearchService
 import javax.validation.Valid
 
 @Api(tags = ["offender-search"], authorizations = [Authorization("ROLE_COMMUNITY")], description = "Provides offender search features for Delius elastic search")
 @RestController
 @RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
-class OffenderSearchController(private val searchService: SearchService) {
+class OffenderSearchController(private val searchService: SearchService, private val securityUserContext: SecurityUserContext) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -87,7 +89,7 @@ class OffenderSearchController(private val searchService: SearchService) {
       @PageableDefault  pageable: Pageable
   ): SearchPhraseResults {
     log.info("Search called with {}", searchPhraseFilter)
-    return searchService.performSearch(searchPhraseFilter, pageable)
+    return searchService.performSearch(searchPhraseFilter, pageable, getOffenderUserAccessFromScopes(securityUserContext))
   }
 
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetail.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.hmpps.offendersearch.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.swagger.annotations.ApiModelProperty
 import java.time.LocalDate
+import java.time.Period
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class OffenderDetail(
     val previousSurname: String? = null,
     @ApiModelProperty(required = true) val offenderId: Long,
@@ -26,4 +29,6 @@ data class OffenderDetail(
     val exclusionMessage: String? = null,
     @ApiModelProperty(value = "map of fields which matched a search term (Only return for phrase searching)", example = "{surname: [\"Smith\"], offenderAliases.surname: [\"SMITH\"]}")
     val highlight: Map<String, List<String>>? = null
-)
+) {
+    val age: Int? get() = dateOfBirth?.let { Period.between(it, LocalDate.now()).years }
+}

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderUserAccess.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderUserAccess.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.hmpps.offendersearch.dto
+
+
+/*
+  A user may or may not be present in the security context.
+  When the user is present in the security context the following apply:
+  1) Access to offenders that have an exclusion list will be allowed when either:
+      a) this user is not on the exclusion list
+      b) client has allowWhenExclusionMatched scope
+  2) Access to offenders that have an inclusion (restriction) will be allowed when either
+      a) this user is on the inclusion (restricted) list
+      b) client has allowWhenInclusionNotMatched scope
+
+  When a user is not present in the security context the following apply:
+  1) Access to offenders that have an exclusion list will be allowed when:
+      a) client has ignoreExclusionsAlways scope
+  2) Access to offenders that have an inclusion (restriction) will be allowed when
+      a) client has ignoreInclusionsAlways scope
+ */
+data class OffenderUserAccess(
+    val username: String? = null,
+    val allowWhenExclusionMatched: Boolean = false,
+    val allowWhenInclusionNotMatched: Boolean = false,
+    val ignoreExclusionsAlways: Boolean = false,
+    val ignoreInclusionsAlways: Boolean = false
+)

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/security/ScopeMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/security/ScopeMapper.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.hmpps.offendersearch.security
+
+import org.springframework.security.core.Authentication
+import uk.gov.justice.hmpps.offendersearch.config.SecurityUserContext
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderUserAccess
+
+
+fun getOffenderUserAccessFromScopes(securityUserContext: SecurityUserContext): OffenderUserAccess = OffenderUserAccess(
+    username = securityUserContext.currentDeliusUsername,
+    ignoreExclusionsAlways = securityUserContext.authentication.hasScope("ignore_delius_exclusions_always"),
+    ignoreInclusionsAlways = securityUserContext.authentication.hasScope("ignore_delius_inclusions_always"),
+    allowWhenExclusionMatched = securityUserContext.authentication.hasScope("allow_when_delius_exclusion_matched"),
+    allowWhenInclusionNotMatched = securityUserContext.authentication.hasScope("allow_when_delius_inclusion_not_matched")
+)
+
+private fun Authentication?.hasScope(scope: String): Boolean = this?.authorities?.any { it.authority == "SCOPE_$scope" }
+    ?: false
+

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/PhraseResultParser.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/PhraseResultParser.kt
@@ -8,6 +8,4 @@ internal fun extractOffenderDetailList(
     hits: Array<SearchHit>,
     phrase: String,
     offenderParser: (json: String) -> OffenderDetail
-): List<OffenderDetail> {
-  return hits.map { offenderParser(it.sourceAsString).mergeHighlights(it.highlightFields, phrase) }
-}
+): List<OffenderDetail> = hits.map { offenderParser(it.sourceAsString).mergeHighlights(it.highlightFields, phrase) }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/SearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/SearchService.kt
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.hmpps.offendersearch.BadRequestException
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderDetail
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderUserAccess
 import uk.gov.justice.hmpps.offendersearch.dto.SearchDto
 import uk.gov.justice.hmpps.offendersearch.dto.SearchPhraseFilter
 import uk.gov.justice.hmpps.offendersearch.dto.SearchPhraseResults
@@ -98,7 +99,7 @@ class SearchService @Autowired constructor(private val hlClient: SearchClient, p
         .must("softDeleted", false)
   }
 
-  fun performSearch(searchPhraseFilter: SearchPhraseFilter, pageable: Pageable): SearchPhraseResults {
+  fun performSearch(searchPhraseFilter: SearchPhraseFilter, pageable: Pageable, offenderUserAccess: OffenderUserAccess): SearchPhraseResults {
     log.info("Search was: \"${searchPhraseFilter.phrase}\"")
     val searchRequest = SearchRequest("offender")
         .source(SearchSourceBuilder()

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetailTest.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.hmpps.offendersearch.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.time.LocalDate
+
+internal class OffenderDetailTest {
+
+  @Test
+  fun `age is calculated from date of birth`() {
+    val expectedAge = LocalDate.now().year - 2000
+    assertThat(OffenderDetail(offenderId = 99, dateOfBirth = LocalDate.parse("2000-01-01")).age).isEqualTo(expectedAge)
+  }
+  @Test
+  fun `age is not present if date of birth is not present`() {
+    assertThat(OffenderDetail(offenderId = 99, dateOfBirth = null).age).isNull()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/util/JwtAuthenticationHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/util/JwtAuthenticationHelper.kt
@@ -29,7 +29,8 @@ class JwtAuthenticationHelper(@Value("\${jwt.signing.key.pair}") privateKeyPair:
 
   fun createJwt(vararg roles: String): String {
     return createJwt(JwtParameters(
-        username = "prison-to-probation",
+        subject = "new-tech",
+        clientId = "new-tech",
         roles = listOf(*roles),
         scope = listOf("read", "write"),
         expiryTime = Duration.ofDays(1)))
@@ -37,7 +38,19 @@ class JwtAuthenticationHelper(@Value("\${jwt.signing.key.pair}") privateKeyPair:
 
   fun createCommunityJwtWithScopes(vararg scopes: String): String {
     return createJwt(JwtParameters(
-        username = "prison-to-probation",
+        subject = "new-tech",
+        clientId = "new-tech",
+        roles = listOf("ROLE_COMMUNITY"),
+        scope = listOf(*scopes),
+        expiryTime = Duration.ofDays(1)))
+  }
+
+  fun createCommunityJwtWithScopes(clientUser: ClientUser, vararg scopes: String): String {
+    return createJwt(JwtParameters(
+        subject = clientUser.subject,
+        clientId = clientUser.clientId,
+        username = clientUser.username,
+        authSource = clientUser.authSource,
         roles = listOf("ROLE_COMMUNITY"),
         scope = listOf(*scopes),
         expiryTime = Duration.ofDays(1)))
@@ -45,15 +58,16 @@ class JwtAuthenticationHelper(@Value("\${jwt.signing.key.pair}") privateKeyPair:
 
   fun createJwt(parameters: JwtParameters): String {
     val claims = mapOf(
-        "user_name" to parameters.username,
-        "user_id" to parameters.userId,
-        "client_id" to "offender-search",
         "authorities" to parameters.roles,
-        "scope" to parameters.roles
-    )
+        "scope" to parameters.scope,
+        "client_id" to parameters.clientId,
+        "auth_source" to parameters.authSource
+    ).apply {
+      parameters.username?.run {this + ("user_name" to parameters.username)}
+    }
     return Jwts.builder()
         .setId(UUID.randomUUID().toString())
-        .setSubject(parameters.username)
+        .setSubject(parameters.subject)
         .addClaims(claims)
         .setExpiration(Date(System.currentTimeMillis() + parameters.expiryTime.toMillis()))
         .signWith(SignatureAlgorithm.RS256, keyPair.private)
@@ -61,12 +75,16 @@ class JwtAuthenticationHelper(@Value("\${jwt.signing.key.pair}") privateKeyPair:
   }
 
   data class JwtParameters(
-      val username: String,
-      val userId: String? = null,
+      val username: String? = null,
+      val subject: String? = null,
+      val clientId: String = "new-tech",
+      val authSource: String = "none",
       val scope: List<String>,
       val roles: List<String>,
       val expiryTime: Duration
   )
+
+  data class ClientUser(val clientId: String, val subject: String, val username: String?, val authSource: String = "delius")
 
   private fun getKeyPair(resource: Resource, alias: String, password: CharArray): KeyPair {
     val store = KeyStore.getInstance("jks")

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/util/JwtAuthenticationHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/util/JwtAuthenticationHelper.kt
@@ -35,6 +35,14 @@ class JwtAuthenticationHelper(@Value("\${jwt.signing.key.pair}") privateKeyPair:
         expiryTime = Duration.ofDays(1)))
   }
 
+  fun createCommunityJwtWithScopes(vararg scopes: String): String {
+    return createJwt(JwtParameters(
+        username = "prison-to-probation",
+        roles = listOf("ROLE_COMMUNITY"),
+        scope = listOf(*scopes),
+        expiryTime = Duration.ofDays(1)))
+  }
+
   fun createJwt(parameters: JwtParameters): String {
     val claims = mapOf(
         "user_name" to parameters.username,


### PR DESCRIPTION
Delius has exclusion/inclusion list for offenders by logged on Delius user. These are used to control access to sensitive offenders or offenders that maybe related to the actually logged on user.

This change allows the ability for clients to choose if they want to honour those lists. By default, clients will have details for sensitive offenders redacted.
Additional scopes can be added to override that for both clients that have a Delius user in context and for those without.

TODO - implement the actually redaction.