### PR TITLE
DT-963 Fix test issue total hits was limited to 10,000

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/SearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/SearchService.kt
@@ -113,6 +113,7 @@ class SearchService @Autowired constructor(private val offenderAccessService: Of
             .from(pageable.offset.toInt())
             .sort("_score")
             .sort("offenderId", DESC)
+            .trackTotalHits(true)
             .aggregation(buildAggregationRequest())
             .highlighter(buildHighlightRequest())
             .suggest(SuggestBuilder()


### PR DESCRIPTION
I did write a test for this, but loading 10,001 offenders just took too long so I ditched it after it passed.