### PR TITLE
Dt 1268 search by team code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
@@ -147,7 +147,7 @@ class OffenderSearchController(private val searchService: SearchService, private
   )
   @ApiOperation(value = "Match prisoners by a list of team codes", notes = "Requires ROLE_COMMUNITY role")
   fun findByTeamCode(
-          @ApiParam(required = true, name = "lduList")
+          @ApiParam(required = true, name = "teamCodeList")
           @PageableDefault  pageable: Pageable,
           @RequestBody teamCodeList : List<String>
   ) : List<OffenderDetail> {

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchController.kt
@@ -135,4 +135,23 @@ class OffenderSearchController(private val searchService: SearchService, private
     return searchService.findByListOfLdu(lduList)
   }
 
+  @PreAuthorize("hasRole('ROLE_COMMUNITY')")
+  @ApiResponses(value = [
+    ApiResponse(code = 401, message = "Unauthorised, requires a valid Oauth2 token"),
+    ApiResponse(code = 403, message = "Forbidden, requires an authorisation with role ROLE_COMMUNITY")
+  ])
+  @PostMapping("/team-codes")
+  @ApiImplicitParams(
+          ApiImplicitParam(name = "page", dataType = "int", paramType = "query", value = "Results page you want to retrieve (0..N)", example = "0", defaultValue = "0"),
+          ApiImplicitParam(name = "size", dataType = "int", paramType = "query", value = "Number of records per page.", example = "10", defaultValue = "10")
+  )
+  @ApiOperation(value = "Match prisoners by a list of team codes", notes = "Requires ROLE_COMMUNITY role")
+  fun findByTeamCode(
+          @ApiParam(required = true, name = "lduList")
+          @PageableDefault  pageable: Pageable,
+          @RequestBody teamCodeList : List<String>
+  ) : List<OffenderDetail> {
+    return searchService.findByListOfTeamCodes(pageable, teamCodeList)
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/LocalstackIntegrationBase.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/LocalstackIntegrationBase.kt
@@ -85,7 +85,7 @@ abstract class LocalstackIntegrationBase {
                 .let { matchingReplacement ->
                   offenderManager.copy(
                       probationArea = ProbationArea(code = matchingReplacement?.code, description = matchingReplacement?.description),
-                      team = Team(localDeliveryUnit = matchingReplacement?.team?.localDeliveryUnit),
+                      team = Team(code = matchingReplacement?.team?.code, localDeliveryUnit = matchingReplacement?.team?.localDeliveryUnit),
                       softDeleted = matchingReplacement?.softDeleted
                   )
                 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchPhraseAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchPhraseAPIIntegrationTest.kt
@@ -1577,6 +1577,7 @@ data class OffenderManagerReplacement(
 )
 
 data class TeamReplacement(
+    val code: String = "N09000",
     val localDeliveryUnit: KeyValue = KeyValue(code="ABC123", description="description"),
     val description: String = "OMU A"
 )

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchTeamCodeListAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchTeamCodeListAPIIntegrationTest.kt
@@ -149,7 +149,7 @@ class OffenderSearchTeamCodeListAPIIntegrationTest : LocalstackIntegrationBase()
         Assertions.assertThat(results).hasSize(3)
         Assertions.assertThat(results[0].offenderManagers?.get(0)?.team?.code).contains("N02000")
         Assertions.assertThat(results[1].offenderManagers?.get(0)?.team?.code).contains("N01000")
-        Assertions.assertThat(results[1].offenderManagers?.get(0)?.team?.code).contains("N01000")
+        Assertions.assertThat(results[2].offenderManagers?.get(0)?.team?.code).contains("N01000")
     }
 
     @Test

--- a/src/test/resources/elasticsearchdata/anne-gramsci-n02.json
+++ b/src/test/resources/elasticsearchdata/anne-gramsci-n02.json
@@ -75,6 +75,7 @@
       "partitionArea": "National Data",
       "softDeleted": false,
       "team": {
+        "code" : "N07588",
         "localDeliveryUnit": {
           "code": "N08ALL",
           "description": "test"


### PR DESCRIPTION
A new endpoint to allow search by team code. This will return all offenders who have an active manager that is part of a team containing a given team code.

Currently the search service code for search by team code & search by ldu are very similar. This can be changed soon when the /ldu-codes endpoint implements paging.