### PR TITLE
Dt 1380 add missing fields they are return from community-api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderAlias.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.offendersearch.dto
 import java.time.LocalDate
 
 data class OffenderAlias(
+  val id: String? = null,
   val dateOfBirth: LocalDate? = null,
   val firstName: String? = null,
   val middleNames: List<String>? = null,

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderDetail.kt
@@ -29,7 +29,9 @@ data class OffenderDetail(
   val exclusionMessage: String? = null,
   @ApiModelProperty(value = "map of fields which matched a search term (Only return for phrase searching)", example = "{surname: [\"Smith\"], offenderAliases.surname: [\"SMITH\"]}")
   val highlight: Map<String, List<String>>? = null,
-  val accessDenied: Boolean? = null
-) {
+  val accessDenied: Boolean? = null,
+  val currentTier: String? = null,
+  val activeProbationManagedSentence: Boolean? = null,
+  ) {
   val age: Int? get() = dateOfBirth?.let { Period.between(it, LocalDate.now()).years }
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderManager.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class OffenderManager(
   val trustOfficer: Human? = null,
-  val staff: Human? = null,
+  val staff: StaffHuman? = null,
   val providerEmployee: Human? = null,
   val partitionArea: String? = null,
   val softDeleted: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderProfile.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderProfile.kt
@@ -9,6 +9,7 @@ data class OffenderProfile(
   val offenderLanguages: OffenderLanguages? = null,
   val religion: String? = null,
   val sexualOrientation: String? = null,
+  val offenderDetails: String? = null,
   val remandStatus: String? = null,
   val previousConviction: PreviousConviction? = null,
   val riskColour: String? = null,

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/StaffHuman.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/StaffHuman.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.hmpps.offendersearch.dto
+
+import io.swagger.annotations.ApiModelProperty
+
+data class StaffHuman(
+  @ApiModelProperty(value = "Staff code", example = "AN001A") val code: String? = null,
+  @ApiModelProperty(value = "Given names", example = "Sheila Linda") val forenames: String? = null,
+  @ApiModelProperty(value = "Family name", example = "Hancock") val surname: String? = null,
+  @ApiModelProperty(value = "When true the not allocated", example = "false") val unallocated: Boolean? = null
+)

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/LocalstackIntegrationBase.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/LocalstackIntegrationBase.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.hmpps.offendersearch.dto.ProbationArea
 import uk.gov.justice.hmpps.offendersearch.dto.Team
 import uk.gov.justice.hmpps.offendersearch.util.JwtAuthenticationHelper
 import uk.gov.justice.hmpps.offendersearch.util.LocalStackHelper
+import kotlin.random.Random.Default.nextInt
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["test", "localstack"])
@@ -62,6 +63,7 @@ abstract class LocalstackIntegrationBase {
         ),
         offenderAliases = it.aliases.map { alias ->
           OffenderAlias(
+            id =  nextInt().toString(),
             firstName = alias.firstName,
             surname = alias.surname,
             dateOfBirth = alias.dateOfBirth

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchPhraseAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderSearchPhraseAPIIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.restassured.RestAssured
 import io.restassured.response.ValidatableResponse
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
@@ -39,6 +40,27 @@ class OffenderSearchPhraseAPIIntegrationTest : LocalstackIntegrationBase() {
       )
 
       hasSingleMatch(phrase = "gramsci", expectedCrn = "X99999")
+    }
+
+    @Test
+    internal fun `a search brings back offender details`() {
+      loadOffenders(
+        OffenderReplacement(
+          crn = "X00001",
+          aliases = listOf(AliasReplacement("Smith", "John")),
+          offenderManagers = listOf(OffenderManagerReplacement("N03", "NPS London"))
+        ),
+      )
+      doSearch("X00001", true)
+        .body("totalElements", equalTo(1))
+        .body("content[0].currentTier", notNullValue())
+        .body("content[0].activeProbationManagedSentence", notNullValue())
+        .body("content[0].offenderAliases[0].id", notNullValue())
+        .body("content[0].offenderManagers[0].staff.code", notNullValue())
+        .body("content[0].offenderManagers[0].staff.unallocated", notNullValue())
+        .body("content[0].offenderManagers[0].team.localDeliveryUnit.code", notNullValue())
+        .body("content[0].offenderManagers[0].team.localDeliveryUnit.description", notNullValue())
+        .body("content[0].offenderProfile.offenderDetails", notNullValue())
     }
   }
 

--- a/src/test/resources/elasticsearchdata/anne-gramsci-n02.json
+++ b/src/test/resources/elasticsearchdata/anne-gramsci-n02.json
@@ -47,7 +47,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/antonio-gramsci-c20.json
+++ b/src/test/resources/elasticsearchdata/antonio-gramsci-c20.json
@@ -49,7 +49,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/antonio-gramsci-n01.json
+++ b/src/test/resources/elasticsearchdata/antonio-gramsci-n01.json
@@ -49,7 +49,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/antonio-gramsci-n02.json
+++ b/src/test/resources/elasticsearchdata/antonio-gramsci-n02.json
@@ -49,7 +49,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/antonio-gramsci-n03.json
+++ b/src/test/resources/elasticsearchdata/antonio-gramsci-n03.json
@@ -49,7 +49,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/duplicateMatches.json
+++ b/src/test/resources/elasticsearchdata/duplicateMatches.json
@@ -123,7 +123,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",
@@ -257,7 +257,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",

--- a/src/test/resources/elasticsearchdata/jane-smith.json
+++ b/src/test/resources/elasticsearchdata/jane-smith.json
@@ -51,7 +51,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/john-smith.json
+++ b/src/test/resources/elasticsearchdata/john-smith.json
@@ -52,7 +52,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/multipleMatches.json
+++ b/src/test/resources/elasticsearchdata/multipleMatches.json
@@ -124,7 +124,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",
@@ -368,7 +368,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",
@@ -641,7 +641,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",
@@ -885,7 +885,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",

--- a/src/test/resources/elasticsearchdata/offender-template.json
+++ b/src/test/resources/elasticsearchdata/offender-template.json
@@ -68,11 +68,17 @@
       },
       "active": true,
       "staff": {
+        "code": "N02IAVU",
         "surname": "Staff",
-        "forenames": "Inactive Staff(N02)"
+        "forenames": "Inactive Staff(N02)",
+        "unallocated": true
       },
       "team": {
         "district": {
+          "code": "N02IAV",
+          "description": "Inactive Level 3(N02)"
+        },
+        "localDeliveryUnit": {
           "code": "N02IAV",
           "description": "Inactive Level 3(N02)"
         },
@@ -132,6 +138,7 @@
   },
   "offenderAliases": [
     {
+      "id": "595141434",
       "firstName": "Jonny",
       "gender": "Male",
       "surname": "Smith",
@@ -184,6 +191,8 @@
       }
     },
     "religion": "Christian"
-  }
+  },
+  "currentTier": "C1",
+  "activeProbationManagedSentence": true
 }
  

--- a/src/test/resources/elasticsearchdata/sam-jones-deleted.json
+++ b/src/test/resources/elasticsearchdata/sam-jones-deleted.json
@@ -51,7 +51,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],

--- a/src/test/resources/elasticsearchdata/singleMatch.json
+++ b/src/test/resources/elasticsearchdata/singleMatch.json
@@ -123,7 +123,7 @@
           "offenderProfile": {
             "riskColour": "red",
             "sexualOrientation": "string",
-            "offenderDetails": {},
+            "offenderDetails": "string",
             "notes": "string",
             "remandStatus": "string",
             "ethnicity": "string",

--- a/src/test/resources/elasticsearchdata/tom-bloggs.json
+++ b/src/test/resources/elasticsearchdata/tom-bloggs.json
@@ -52,7 +52,7 @@
     "immigrationStatus": "string",
     "nationality": "string",
     "notes": "string",
-    "offenderDetails": {},
+    "offenderDetails": "string",
     "offenderLanguages": {
       "languageConcerns": "string",
       "otherLanguages": [ "string" ],


### PR DESCRIPTION
See src/test/resources/elasticsearchdata/offender-template.json for the fields that have been added to community-api but only now reflected in the search API