### PR TITLE
Allow service to access ES in the associated docker-compose container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=localstack,dev
+      - ELASTICSEARCH_HOST=localstack
 
   oauth:
     image: quay.io/hmpps/hmpps-auth:latest


### PR DESCRIPTION
Allows the containers in the docker-compose stack to communicate. The actual fix might be in the localstack profile itself but I'm not sure if this is also being used in other contexts