### PR TITLE
Bump HMPPS Gradle plugin to 4.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.1"
   kotlin("plugin.spring") version "1.6.0"
 }
 


### PR DESCRIPTION
This suppress jackson vulnerability CVE-2020-36518 in trivyignore
