### PR TITLE
✨ PIC-2311 - Add match-with-scores endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ the build pipeline too.
 Note the required localstack container for both tests and local running.
 
 ```$bash
-$ ./gradlew clean install test
+$ ./gradlew clean build test
 $ ./gradlew bootRun --args='--spring.profiles.active=dev,localstack'
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,16 @@ services:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
 
+  hmpps-person-match-score:
+    image: quay.io/hmpps/hmpps-person-match-score:latest
+    networks:
+      - hmpps
+    container_name: hmpps-person-match-score
+    ports:
+      - "8097:5000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+
   localstack:
     image: localstack/localstack:0.11.2
     networks:

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/config/WebClientConfiguration.kt
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient
 @Configuration
 class WebClientConfiguration(
   @Value("\${community.endpoint.url}") private val communityRootUri: String,
+  @Value("\${hmpps-person-match-score.endpoint.url}") private val hmppsPersonMatchScoreRootUri: String,
   private val securityUserContext: SecurityUserContext
 ) {
 
@@ -20,6 +21,13 @@ class WebClientConfiguration(
     return WebClient.builder()
       .baseUrl(communityRootUri)
       .filter(addAuthHeaderFilterFunction())
+      .build()
+  }
+
+  @Bean
+  fun hmppsPersonMatchScoreWebClient(): WebClient {
+    return WebClient.builder()
+      .baseUrl(hmppsPersonMatchScoreRootUri)
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
@@ -22,7 +22,7 @@ import javax.validation.Valid
 
 @Api(tags = ["offender-match"], authorizations = [Authorization("ROLE_COMMUNITY")], description = "Provides offender matching features for Delius elastic search")
 @RestController
-@RequestMapping(value = ["match"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 @PreAuthorize("hasRole('ROLE_COMMUNITY')")
 class OffenderMatchController(private val matchService: MatchService) {
   companion object {
@@ -32,8 +32,18 @@ class OffenderMatchController(private val matchService: MatchService) {
   @ApiOperation(value = "Match for an offender in Delius ElasticSearch. It will return the best group of matching offenders based on the request", notes = "Specify the request criteria to match against", authorizations = [Authorization("ROLE_COMMUNITY")], nickname = "match")
   @ApiResponses(value = [ApiResponse(code = 200, message = "OK", response = OffenderMatches::class), ApiResponse(code = 400, message = "Invalid Request", response = BadRequestException::class), ApiResponse(code = 404, message = "Not found", response = NotFoundException::class)])
   @PostMapping
+  @RequestMapping(value = ["match"])
   fun matchOffenders(@Valid @RequestBody matchRequest: MatchRequest): OffenderMatches {
     log.info("Match called with {}", matchRequest)
+    return matchService.match(matchRequest)
+  }
+
+  @ApiOperation(value = "Match for an offender in Delius ElasticSearch. It will return the best group of matching offenders based on the request", notes = "Specify the request criteria to match against", authorizations = [Authorization("ROLE_COMMUNITY")], nickname = "match")
+  @ApiResponses(value = [ApiResponse(code = 200, message = "OK", response = OffenderMatches::class), ApiResponse(code = 400, message = "Invalid Request", response = BadRequestException::class), ApiResponse(code = 404, message = "Not found", response = NotFoundException::class)])
+  @PostMapping
+  @RequestMapping(value = ["match-with-probabilities"])
+  fun matchOffendersWithProbabilities(@Valid @RequestBody matchRequest: MatchRequest): OffenderMatches {
+    log.info("Match with probabilities called with {}", matchRequest)
     return matchService.match(matchRequest)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
@@ -13,18 +13,25 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import uk.gov.justice.hmpps.offendersearch.BadRequestException
 import uk.gov.justice.hmpps.offendersearch.NotFoundException
 import uk.gov.justice.hmpps.offendersearch.dto.MatchRequest
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatch
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatches
+import uk.gov.justice.hmpps.offendersearch.services.MatchScore
+import uk.gov.justice.hmpps.offendersearch.services.MatchScoreResult
 import uk.gov.justice.hmpps.offendersearch.services.MatchService
+import uk.gov.justice.hmpps.offendersearch.services.MatchScoreService
+import java.util.stream.Collectors
 import javax.validation.Valid
 
 @Api(tags = ["offender-match"], authorizations = [Authorization("ROLE_COMMUNITY")], description = "Provides offender matching features for Delius elastic search")
 @RestController
 @RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 @PreAuthorize("hasRole('ROLE_COMMUNITY')")
-class OffenderMatchController(private val matchService: MatchService) {
+class OffenderMatchController(private val matchService: MatchService, private val matchScoreService: MatchScoreService) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -38,12 +45,26 @@ class OffenderMatchController(private val matchService: MatchService) {
     return matchService.match(matchRequest)
   }
 
-  @ApiOperation(value = "Match for an offender in Delius ElasticSearch. It will return the best group of matching offenders based on the request", notes = "Specify the request criteria to match against", authorizations = [Authorization("ROLE_COMMUNITY")], nickname = "match")
+  @ApiOperation(value = "Match for an offender in Delius ElasticSearch. It will return the best group of matching offenders based on the request as well as a match probability from hmpps-person-match-score", notes = "Specify the request criteria to match against", authorizations = [Authorization("ROLE_COMMUNITY")], nickname = "match-with-scores")
   @ApiResponses(value = [ApiResponse(code = 200, message = "OK", response = OffenderMatches::class), ApiResponse(code = 400, message = "Invalid Request", response = BadRequestException::class), ApiResponse(code = 404, message = "Not found", response = NotFoundException::class)])
   @PostMapping
-  @RequestMapping(value = ["match-with-probabilities"])
+  @RequestMapping(value = ["match-with-scores"])
   fun matchOffendersWithProbabilities(@Valid @RequestBody matchRequest: MatchRequest): OffenderMatches {
     log.info("Match with probabilities called with {}", matchRequest)
-    return matchService.match(matchRequest)
+    return matchService.match(matchRequest) withMatchScoresFrom matchRequest
+  }
+
+  private infix fun OffenderMatches.withMatchScoresFrom(matchRequest: MatchRequest) : OffenderMatches {
+    return this.copy(
+      matches = this.matches withMatchScoresFrom matchRequest
+    )
+  }
+
+  private infix fun List<OffenderMatch>.withMatchScoresFrom(matchRequest: MatchRequest) : List<OffenderMatch> {
+    return this.map { it withMatchScore matchScoreService.score(matchRequest, it).block() }
+  }
+
+  private infix fun OffenderMatch.withMatchScore(matchScore: MatchScore?) : OffenderMatch {
+    return this.copy(matchProbability = matchScore?.matchProbability)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchController.kt
@@ -13,18 +13,12 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 import uk.gov.justice.hmpps.offendersearch.BadRequestException
 import uk.gov.justice.hmpps.offendersearch.NotFoundException
 import uk.gov.justice.hmpps.offendersearch.dto.MatchRequest
-import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatch
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatches
-import uk.gov.justice.hmpps.offendersearch.services.MatchScore
-import uk.gov.justice.hmpps.offendersearch.services.MatchScoreResult
-import uk.gov.justice.hmpps.offendersearch.services.MatchService
 import uk.gov.justice.hmpps.offendersearch.services.MatchScoreService
-import java.util.stream.Collectors
+import uk.gov.justice.hmpps.offendersearch.services.MatchService
 import javax.validation.Valid
 
 @Api(tags = ["offender-match"], authorizations = [Authorization("ROLE_COMMUNITY")], description = "Provides offender matching features for Delius elastic search")
@@ -49,22 +43,12 @@ class OffenderMatchController(private val matchService: MatchService, private va
   @ApiResponses(value = [ApiResponse(code = 200, message = "OK", response = OffenderMatches::class), ApiResponse(code = 400, message = "Invalid Request", response = BadRequestException::class), ApiResponse(code = 404, message = "Not found", response = NotFoundException::class)])
   @PostMapping
   @RequestMapping(value = ["match-with-scores"])
-  fun matchOffendersWithProbabilities(@Valid @RequestBody matchRequest: MatchRequest): OffenderMatches {
-    log.info("Match with probabilities called with {}", matchRequest)
-    return matchService.match(matchRequest) withMatchScoresFrom matchRequest
+  fun matchWithScores(@Valid @RequestBody matchRequest: MatchRequest): OffenderMatches {
+    log.info("Match with scores called with {}", matchRequest)
+    return matchService.match(matchRequest) scoredAgainst matchRequest
   }
 
-  private infix fun OffenderMatches.withMatchScoresFrom(matchRequest: MatchRequest) : OffenderMatches {
-    return this.copy(
-      matches = this.matches withMatchScoresFrom matchRequest
-    )
-  }
-
-  private infix fun List<OffenderMatch>.withMatchScoresFrom(matchRequest: MatchRequest) : List<OffenderMatch> {
-    return this.map { it withMatchScore matchScoreService.score(matchRequest, it).block() }
-  }
-
-  private infix fun OffenderMatch.withMatchScore(matchScore: MatchScore?) : OffenderMatch {
-    return this.copy(matchProbability = matchScore?.matchProbability)
+  private infix fun OffenderMatches.scoredAgainst(matchRequest: MatchRequest): OffenderMatches {
+    return copy(matches = matchScoreService.scoreAll(matches, matchRequest))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/MatchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/MatchRequest.kt
@@ -14,5 +14,6 @@ data class MatchRequest(
   @ApiModelProperty(value = "Police National Computer (PNC) number", example = "2018/0123456X", position = 4) val pncNumber: String? = null,
   @ApiModelProperty(value = "Criminal Records Office (CRO) number", example = "SF80/655108T", position = 5) val croNumber: String? = null,
   @ApiModelProperty(value = "The Offender NOMIS Id (aka prison number/offender no in DPS)", example = "G5555TT", position = 7) val nomsNumber: String? = null,
-  @ApiModelProperty(value = "Filter so only offenders on a current sentence managed by probation will be returned", example = "true", position = 8) val activeSentence: Boolean = false
+  @ApiModelProperty(value = "Filter so only offenders on a current sentence managed by probation will be returned", example = "true", position = 8) val activeSentence: Boolean = false,
+  @ApiModelProperty(value = "If available, the name of the system that the data in this match request has originated from", example = "LIBRA", position = 9) val sourceSystem: String? = null
 )

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderMatch.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderMatch.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.hmpps.offendersearch.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.annotations.ApiModelProperty
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class OffenderMatch(
   @ApiModelProperty(required = true, value = "Details of the matching offender")
   val offender: OffenderDetail,

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderMatch.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/dto/OffenderMatch.kt
@@ -4,5 +4,7 @@ import io.swagger.annotations.ApiModelProperty
 
 data class OffenderMatch(
   @ApiModelProperty(required = true, value = "Details of the matching offender")
-  val offender: OffenderDetail
+  val offender: OffenderDetail,
+  @ApiModelProperty(required = false, value = "Match probability score if available")
+  val matchProbability: Double? = null
 )

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.offendersearch.services
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -79,6 +80,7 @@ private data class MatchScoreResponse(
   val match_probability: ValueDouble
 )
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 private data class ValuePair(
   val `0`: String?,
   val `1`: String?

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.hmpps.offendersearch.services
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import uk.gov.justice.hmpps.offendersearch.dto.MatchRequest
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatch
+import java.time.format.DateTimeFormatter
+
+@Service
+class MatchScoreService(@Qualifier("hmppsPersonMatchScoreWebClient") private val webClient: WebClient) {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  internal fun score(matchRequest: MatchRequest, offenderMatch: OffenderMatch): Mono<MatchScore> {
+    return webClient.post()
+      .uri("/match")
+      .bodyValue(matchRequest combinedIntoScoreRequestWith offenderMatch)
+      .retrieve()
+      .bodyToMono(MatchScoreResponse::class.java)
+      .map { MatchScore(it.match_probability.`0`) }
+      .onErrorResume {
+        log.warn("There was an error retrieving probability scores from hmpps-person-match-score, returning empty.", it)
+        Mono.empty()
+      }
+  }
+}
+
+
+private infix fun MatchRequest.combinedIntoScoreRequestWith(offenderMatch: OffenderMatch): MatchScoreRequest {
+  return MatchScoreRequest(
+    unique_id = ValuePair("1", "2"),
+    first_name = ValuePair(this.firstName, offenderMatch.offender.firstName),
+    surname = ValuePair(this.surname, offenderMatch.offender.surname),
+    dob = ValuePair(
+      this.dateOfBirth?.format(DateTimeFormatter.ISO_DATE),
+      offenderMatch.offender.dateOfBirth?.format(DateTimeFormatter.ISO_DATE)
+    ),
+    pnc_number = ValuePair(this.pncNumber, offenderMatch.offender.otherIds?.pncNumber),
+    source_dataset = ValuePair("LIBRA", "DELIUS")
+  )
+}
+
+internal data class MatchScore(val matchProbability: Double)
+
+
+sealed class MatchScoreResult {
+  object Empty : MatchScoreResult()
+  data class Match(val matchProbability: Double) : MatchScoreResult()
+}
+
+private data class MatchScoreRequest(
+  val unique_id: ValuePair,
+  val first_name: ValuePair,
+  val surname: ValuePair,
+  val dob: ValuePair,
+  val pnc_number: ValuePair,
+  val source_dataset: ValuePair
+)
+
+private data class MatchScoreResponse(
+  val match_probability: ValueDouble
+)
+
+private data class ValuePair(
+  val `0`: String?,
+  val `1`: String?
+)
+
+private data class ValueDouble(
+  val `0`: Double
+)

--- a/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreService.kt
@@ -52,7 +52,6 @@ class MatchScoreService(@Qualifier("hmppsPersonMatchScoreWebClient") private val
   }
 }
 
-
 private infix fun MatchRequest.combinedIntoScoreRequestWith(offenderMatch: OffenderMatch): MatchScoreRequest {
   return MatchScoreRequest(
     unique_id = ValuePair("1", "2"),
@@ -63,7 +62,7 @@ private infix fun MatchRequest.combinedIntoScoreRequestWith(offenderMatch: Offen
       offenderMatch.offender.dateOfBirth?.format(DateTimeFormatter.ISO_DATE)
     ),
     pnc_number = ValuePair(this.pncNumber, offenderMatch.offender.otherIds?.pncNumber),
-    source_dataset = ValuePair("LIBRA", "DELIUS")
+    source_dataset = ValuePair(this.sourceSystem ?: "UNKNOWN", "DELIUS")
   )
 }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,4 +11,4 @@ spring:
 community:
   endpoint.url: http://localhost:8096
 hmpps-person-match-score:
-  endpoint.url: http://localhost:8096
+  endpoint.url: http://localhost:8097

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,3 +10,5 @@ spring:
 
 community:
   endpoint.url: http://localhost:8096
+hmpps-person-match-score:
+  endpoint.url: http://localhost:8096

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.hmpps.offendersearch.controllers
 
 import io.restassured.RestAssured.given
+import io.restassured.config.JsonConfig
+import io.restassured.config.RestAssuredConfig
+import io.restassured.path.json.config.JsonPathConfig
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
@@ -132,9 +135,15 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
         )
       )
 
-      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScore()
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScore("2018/0123456X", "0.9172587927")
 
       given()
+        .config(RestAssuredConfig
+          .config()
+          .jsonConfig(JsonConfig
+            .jsonConfig()
+            .numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE))
+        )
         .auth()
         .oauth2(jwtAuthenticationHelper.createJwt("ROLE_COMMUNITY"))
         .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
@@ -95,7 +95,7 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
         .oauth2(jwtAuthenticationHelper.createJwt("ROLE_COMMUNITY"))
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("{\"surname\": \"Smith\"}")
-        .post("/match-with-probabilities")
+        .post("/match-with-scores")
         .then()
         .statusCode(200)
     }
@@ -107,7 +107,7 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
         .oauth2(jwtAuthenticationHelper.createJwt("ROLE_BINGO"))
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("{\"surname\": \"Smith\"}")
-        .post("/match-with-probabilities")
+        .post("/match-with-scores")
         .then()
         .statusCode(403)
     }
@@ -147,7 +147,7 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
             activeSentence = true
           )
         )
-        .post("/match-with-probabilities")
+        .post("/match-with-scores")
         .then()
         .statusCode(200)
         .body("matches.findall.size()", equalTo(1))
@@ -190,7 +190,7 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
             activeSentence = true
           )
         )
-        .post("/match-with-probabilities")
+        .post("/match-with-scores")
         .then()
         .statusCode(200)
         .body("matches.findall.size()", equalTo(1))

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerAPIIntegrationTest.kt
@@ -138,11 +138,14 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
       HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScore("2018/0123456X", "0.9172587927")
 
       given()
-        .config(RestAssuredConfig
-          .config()
-          .jsonConfig(JsonConfig
-            .jsonConfig()
-            .numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE))
+        .config(
+          RestAssuredConfig
+            .config()
+            .jsonConfig(
+              JsonConfig
+                .jsonConfig()
+                .numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)
+            )
         )
         .auth()
         .oauth2(jwtAuthenticationHelper.createJwt("ROLE_COMMUNITY"))
@@ -153,7 +156,8 @@ internal class OffenderMatchControllerAPIIntegrationTest : OffenderMatchAPIInteg
             firstName = "ann",
             dateOfBirth = LocalDate.of(1988, 1, 6),
             pncNumber = "2018/0123456X",
-            activeSentence = true
+            activeSentence = true,
+            sourceSystem = "LIBRA"
           )
         )
         .post("/match-with-scores")

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/controllers/OffenderMatchControllerTest.kt
@@ -19,11 +19,9 @@ import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import reactor.core.publisher.Mono
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderDetail
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatch
 import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatches
-import uk.gov.justice.hmpps.offendersearch.services.MatchScore
 import uk.gov.justice.hmpps.offendersearch.services.MatchScoreService
 import uk.gov.justice.hmpps.offendersearch.services.MatchService
 import uk.gov.justice.hmpps.offendersearch.util.JwtAuthenticationHelper
@@ -95,7 +93,7 @@ internal class OffenderMatchControllerTest {
   fun `OK response with valid request to match-with-scores`() {
     val offenderMatch = OffenderMatch(OffenderDetail(offenderId = 123))
     whenever(matchService.match(any())).thenReturn(OffenderMatches(listOf(offenderMatch)))
-    whenever(matchScoreService.score(any(), eq(offenderMatch))).thenReturn(Mono.just(MatchScore(0.92)))
+    whenever(matchScoreService.scoreAll(eq(listOf(offenderMatch)), any())).thenReturn(listOf(OffenderMatch(matchProbability = 0.92, offender = OffenderDetail(offenderId = 1))))
 
     RestAssured.given()
       .auth()

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreServiceTest.kt
@@ -23,7 +23,7 @@ import java.time.LocalDate
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 internal class MatchScoreServiceTest {
   @Autowired
-  private lateinit var matchScoreService : MatchScoreService
+  private lateinit var matchScoreService: MatchScoreService
 
   @BeforeEach
   internal fun setUp() {
@@ -38,7 +38,8 @@ internal class MatchScoreServiceTest {
         firstName = "ann",
         surname = "gramsci",
         dateOfBirth = LocalDate.of(1988, 1, 6),
-        pncNumber = "2018/0123456X"
+        pncNumber = "2018/0123456X",
+        sourceSystem = "LIBRA"
       )
 
       val match = OffenderMatch(
@@ -68,7 +69,8 @@ internal class MatchScoreServiceTest {
         firstName = "ann",
         surname = "gramsci",
         dateOfBirth = LocalDate.of(1988, 1, 6),
-        pncNumber = "2018/0123456X"
+        pncNumber = "2018/0123456X",
+        sourceSystem = "LIBRA"
       )
 
       val match1 = OffenderMatch(
@@ -110,7 +112,8 @@ internal class MatchScoreServiceTest {
         firstName = "ann",
         surname = "gramsci",
         dateOfBirth = LocalDate.of(1988, 1, 6),
-        pncNumber = "2018/0123456X"
+        pncNumber = "2018/0123456X",
+        sourceSystem = "LIBRA"
       )
 
       val match = OffenderMatch(
@@ -132,6 +135,36 @@ internal class MatchScoreServiceTest {
       )
 
       assertThat(matchScores[0].matchProbability).isNull()
+    }
+
+    @Test
+    fun `if no source system is provided then use UNKNOWN`() {
+      val matchRequest = MatchRequest(
+        firstName = "ann",
+        surname = "gramsci",
+        dateOfBirth = LocalDate.of(1988, 1, 6),
+        pncNumber = "2018/0123456X"
+      )
+
+      val match = OffenderMatch(
+        OffenderDetail(
+          firstName = "anne",
+          surname = "gramsci",
+          dateOfBirth = LocalDate.of(1988, 1, 6),
+          offenderId = 123,
+          otherIds = IDs(pncNumber = "2018/0123456X")
+        )
+      )
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScore("2018/0123456X", "0.9172587927", "UNKNOWN")
+
+      val matchScore = matchScoreService.scoreAll(listOf(match), matchRequest)
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.verify(
+        WireMock.postRequestedFor(WireMock.urlEqualTo("/match"))
+      )
+
+      assertThat(matchScore[0].matchProbability).isEqualTo(0.9172587927)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/services/MatchScoreServiceTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.hmpps.offendersearch.services
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.hmpps.offendersearch.dto.IDs
+import uk.gov.justice.hmpps.offendersearch.dto.MatchRequest
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderDetail
+import uk.gov.justice.hmpps.offendersearch.dto.OffenderMatch
+import uk.gov.justice.hmpps.offendersearch.wiremock.HmppsPersonMatchScoreExtension
+import java.time.LocalDate
+
+@ExtendWith(HmppsPersonMatchScoreExtension::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = ["test"])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+internal class MatchScoreServiceTest {
+  @Autowired
+  private lateinit var matchScoreService : MatchScoreService
+
+  @Nested
+  inner class Score {
+    @Test
+    fun `return a score for a match`() {
+      val matchRequest = MatchRequest(
+        firstName = "ann",
+        surname = "gramsci",
+        dateOfBirth = LocalDate.of(1988, 1, 6),
+        pncNumber = "2018/0123456X"
+      )
+
+      val match = OffenderMatch(
+        OffenderDetail(
+          firstName = "anne",
+          surname = "gramsci",
+          dateOfBirth = LocalDate.of(1988, 1, 6),
+          offenderId = 123,
+          otherIds = IDs(pncNumber = "2018/0123456X")
+        )
+      )
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScore()
+
+      val matchScore = matchScoreService.score(matchRequest, match).block()
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.verify(
+        WireMock.postRequestedFor(WireMock.urlEqualTo("/match"))
+      )
+
+      assertThat(matchScore?.matchProbability).isEqualTo(0.9172587927)
+    }
+
+    @Test
+    fun `if the match score request fails then return empty`() {
+      val matchRequest = MatchRequest(
+        firstName = "ann",
+        surname = "gramsci",
+        dateOfBirth = LocalDate.of(1988, 1, 6),
+        pncNumber = "2018/0123456X"
+      )
+
+      val match = OffenderMatch(
+        OffenderDetail(
+          firstName = "anne",
+          surname = "gramsci",
+          dateOfBirth = LocalDate.of(1988, 1, 6),
+          offenderId = 123,
+          otherIds = IDs(pncNumber = "2018/0123456X")
+        )
+      )
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.stubPersonMatchScoreError()
+
+      val matchScore = matchScoreService.score(matchRequest, match).block()
+
+      HmppsPersonMatchScoreExtension.hmppsPersonMatchScore.verify(
+        WireMock.postRequestedFor(WireMock.urlEqualTo("/match"))
+      )
+
+      assertThat(matchScore?.matchProbability).isNull()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
@@ -112,27 +112,27 @@ private const val RESPONSE = """{
 
 private const val REQUEST = """{
   "unique_id": {
-    "0": "1111",
-    "1": "4444"
+    "0": "1",
+    "1": "2"
   },
   "first_name": {
     "0": "ann",
     "1": "anne"
   },
   "surname": {
-    "0": "grammsci",
+    "0": "gramsci",
     "1": "gramsci"
   },
   "dob": {
-    "0": "1988-01-07",
+    "0": "1988-01-06",
     "1": "1988-01-06"
   },
   "pnc_number": {
-    "0": "3018/0123456X",
+    "0": "2018/0123456X",
     "1": "2018/0123456X"
   },
   "source_dataset": {
-    "0": "COMMON_PLATFORM",
+    "0": "LIBRA",
     "1": "DELIUS"
   }
 }"""

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.hmpps.offendersearch.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -132,7 +134,7 @@ private const val REQUEST = """{
     "1": "[pncNumber]"
   },
   "source_dataset": {
-    "0": "LIBRA",
+    "0": "[sourceSystem]",
     "1": "DELIUS"
   }
 }"""
@@ -142,18 +144,19 @@ class HmppsPersonMatchScoreMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 9091
   }
 
-  fun stubPersonMatchScore(pnc: String, matchProbability: String) {
+  fun stubPersonMatchScore(pnc: String, matchProbability: String, sourceSystem: String = "LIBRA") {
     val request = REQUEST.replace("[pncNumber]", pnc)
+      .replace("[sourceSystem]", sourceSystem)
     val response = RESPONSE.replace("[matchProbability]", matchProbability)
     stubFor(
       post("/match")
         .withRequestBody(equalToJson(request))
         .willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(response)
-          .withStatus(200)
-      )
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(response)
+            .withStatus(200)
+        )
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
@@ -1,0 +1,169 @@
+package uk.gov.justice.hmpps.offendersearch.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class HmppsPersonMatchScoreExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+  companion object {
+    @JvmField
+    val hmppsPersonMatchScore = HmppsPersonMatchScoreMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    hmppsPersonMatchScore.start()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    hmppsPersonMatchScore.resetRequests()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    hmppsPersonMatchScore.stop()
+  }
+}
+
+private const val RESPONSE = """{
+    "dob_std_l": {
+        "0": "2009-07-06"
+    },
+    "dob_std_r": {
+        "0": "2009-07-06"
+    },
+    "forename1_std_l": {
+        "0": "lily"
+    },
+    "forename1_std_r": {
+        "0": "lily"
+    },
+    "forename2_std_l": {
+        "0": null
+    },
+    "forename2_std_r": {
+        "0": null
+    },
+    "forename3_std_l": {
+        "0": null
+    },
+    "forename3_std_r": {
+        "0": null
+    },
+    "forename4_std_l": {
+        "0": null
+    },
+    "forename4_std_r": {
+        "0": null
+    },
+    "forename5_std_l": {
+        "0": null
+    },
+    "forename5_std_r": {
+        "0": null
+    },
+    "gamma_dob_std": {
+        "0": 5
+    },
+    "gamma_forename1_std": {
+        "0": 3
+    },
+    "gamma_forename2_std": {
+        "0": -1
+    },
+    "gamma_forename3_std": {
+        "0": -1
+    },
+    "gamma_pnc_number_std": {
+        "0": -1
+    },
+    "gamma_surname_std": {
+        "0": 1
+    },
+    "match_probability": {
+        "0": 0.9172587927
+    },
+    "pnc_number_std_l": {
+        "0": "2001/0141640Y"
+    },
+    "pnc_number_std_r": {
+        "0": null
+    },
+    "source_dataset_l": {
+        "0": "COMMON_PLATFORM"
+    },
+    "source_dataset_r": {
+        "0": "DELIUS"
+    },
+    "surname_std_l": {
+        "0": "robinson"
+    },
+    "surname_std_r": {
+        "0": "robibnson"
+    },
+    "unique_id_l": {
+        "0": "nan"
+    },
+    "unique_id_r": {
+        "0": "nan"
+    }
+}"""
+
+private const val REQUEST = """{
+  "unique_id": {
+    "0": "1111",
+    "1": "4444"
+  },
+  "first_name": {
+    "0": "ann",
+    "1": "anne"
+  },
+  "surname": {
+    "0": "grammsci",
+    "1": "gramsci"
+  },
+  "dob": {
+    "0": "1988-01-07",
+    "1": "1988-01-06"
+  },
+  "pnc_number": {
+    "0": "3018/0123456X",
+    "1": "2018/0123456X"
+  },
+  "source_dataset": {
+    "0": "COMMON_PLATFORM",
+    "1": "DELIUS"
+  }
+}"""
+
+class HmppsPersonMatchScoreMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 9091
+  }
+
+  fun stubPersonMatchScore() {
+    stubFor(
+      post("/match")
+        .withRequestBody(equalToJson(REQUEST))
+        .willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(RESPONSE)
+          .withStatus(200)
+      )
+    )
+  }
+
+  fun stubPersonMatchScoreError() {
+    stubFor(
+      post("/match")
+        .withRequestBody(equalToJson(REQUEST))
+        .willReturn(
+          aResponse()
+            .withBody("ERROR")
+            .withStatus(500)
+        )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offendersearch/wiremock/HmppsPersonMatchScoreMockServer.kt
@@ -82,7 +82,7 @@ private const val RESPONSE = """{
         "0": 1
     },
     "match_probability": {
-        "0": 0.9172587927
+        "0": [matchProbability]
     },
     "pnc_number_std_l": {
         "0": "2001/0141640Y"
@@ -127,9 +127,9 @@ private const val REQUEST = """{
     "0": "1988-01-06",
     "1": "1988-01-06"
   },
-  "pnc_number": {
+  "pnc_number": {    
     "0": "2018/0123456X",
-    "1": "2018/0123456X"
+    "1": "[pncNumber]"
   },
   "source_dataset": {
     "0": "LIBRA",
@@ -142,14 +142,16 @@ class HmppsPersonMatchScoreMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 9091
   }
 
-  fun stubPersonMatchScore() {
+  fun stubPersonMatchScore(pnc: String, matchProbability: String) {
+    val request = REQUEST.replace("[pncNumber]", pnc)
+    val response = RESPONSE.replace("[matchProbability]", matchProbability)
     stubFor(
       post("/match")
-        .withRequestBody(equalToJson(REQUEST))
+        .withRequestBody(equalToJson(request))
         .willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withBody(RESPONSE)
+          .withBody(response)
           .withStatus(200)
       )
     )

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,10 +23,3 @@ community:
   endpoint.url: http://localhost:9091
 hmpps-person-match-score:
   endpoint.url: http://localhost:9091
-
-logging.level:
-  com:
-    github:
-      tomakehurst:
-        wiremock: TRACE
-  uk.gov.justice.hmpps.offendersearch.services.MatchScoreService: TRACE

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,3 +21,12 @@ management.endpoint:
 
 community:
   endpoint.url: http://localhost:9091
+hmpps-person-match-score:
+  endpoint.url: http://localhost:9091
+
+logging.level:
+  com:
+    github:
+      tomakehurst:
+        wiremock: TRACE
+  uk.gov.justice.hmpps.offendersearch.services.MatchScoreService: TRACE


### PR DESCRIPTION
This PR creates a new match endpoint which, in addition to the existing match functionality, also fetches match probability scores for each of the matches found. These are sourced per-match from `hmpps-person-match-score` which is a RESTful API around a matching algorithm created by the data science team.

`POST /match-with-scores` returns:

```
{
    "matches": [
        {
            "offender": {
                "firstName": "foo",
                ...
            },
            "matchProbability": 0.9999999997   <- We've added this
        }
    ],
    "matchedBy": "ALL_SUPPLIED"
}
```

This is useful to the probation in court team who eventually want to use these scores to judge whether a match is likely to be correct, saving users time by preventing them from having to manually confirm matches that are clearly wrong. 

We don't want the call to fail if the probability scores aren't available so we've added error handling to allow it to fail gracefully. Currently it just logs the fact that a failure has occurred and returns nothing for that `matchProbability`.  

[More info here](https://dsdmoj.atlassian.net/browse/PIC-2311)