### PR TITLE
PI-1050 Return and sort by raw Elasticsearch score

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearch.kt
@@ -59,7 +59,7 @@ data class AddressSearchResponses(
 data class AddressSearchResponse(
   val person: Person,
   val address: Address,
-  val matchScore: Int,
+  val matchScore: Float,
 )
 
 data class PersonDetail(

--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearchService.kt
@@ -31,7 +31,7 @@ class AddressSearchService(val elasticSearchClient: RestHighLevelClient, val obj
           )
         }
     }
-    .sortedByDescending { it.matchScore }
+    .sortedWith(compareByDescending<AddressSearchResponse> { it.matchScore }.thenBy { it.address.id })
     .take(maxResults)
 
   private fun Array<String>.matches(): Boolean = map {

--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/addresssearch/AddressSearchService.kt
@@ -6,7 +6,6 @@ import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestHighLevelClient
 import org.elasticsearch.search.SearchHits
 import org.springframework.stereotype.Service
-import kotlin.math.roundToInt
 
 @Service
 class AddressSearchService(val elasticSearchClient: RestHighLevelClient, val objectMapper: ObjectMapper) {
@@ -18,21 +17,22 @@ class AddressSearchService(val elasticSearchClient: RestHighLevelClient, val obj
     return AddressSearchResponses(res.hits.toAddressSearchResponse(maxResults))
   }
 
-  fun SearchHits.toAddressSearchResponse(maxResults: Int): List<AddressSearchResponse> = hits.flatMap { hit ->
-    val personDetail = objectMapper.readValue(hit.sourceAsString, PersonDetail::class.java).toPerson()
-    hit.innerHits.values.flatMap { innerHit ->
-      innerHit.hits.mapNotNull {
-        if (it.matchedQueries.matches()) {
-          Pair(
+  fun SearchHits.toAddressSearchResponse(maxResults: Int): List<AddressSearchResponse> = hits
+    .flatMap { hit ->
+      val personDetail = objectMapper.readValue(hit.sourceAsString, PersonDetail::class.java).toPerson()
+      hit.innerHits.values
+        .flatMap { it.hits.toList() }
+        .filter { it.matchedQueries.matches() }
+        .map {
+          AddressSearchResponse(
+            personDetail,
             objectMapper.readValue(it.sourceAsString, PersonAddress::class.java).toAddress(),
-            ((it.score / maxScore) * 100).roundToInt(),
+            it.score,
           )
-        } else {
-          null
         }
-      }
-    }.map { AddressSearchResponse(personDetail, it.first, it.second) }
-  }.sortedByDescending { it.matchScore }.take(maxResults)
+    }
+    .sortedByDescending { it.matchScore }
+    .take(maxResults)
 
   private fun Array<String>.matches(): Boolean = map {
     when (it) {


### PR DESCRIPTION
To avoid binning of similar scores resulting in inconsistent ordering

Note: Delius doesn't use the matchScore value however it does map it as an `int`.  This should be fine though as Jackson automatically deserializes `float`s to `int`s. See https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.12.3/com/fasterxml/jackson/databind/DeserializationFeature.html#ACCEPT_FLOAT_AS_INT