### PR TITLE
HIA-292 Remove isValid as part of search request body documentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/dto/SearchDto.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/dto/SearchDto.kt
@@ -14,6 +14,7 @@ data class SearchDto( // todo confirm description and examples
   @Schema(required = false, example = "G5555TT") val nomsNumber: String? = null,
   @Schema(required = false, example = "false") val includeAliases: Boolean? = false,
 ) {
+  @get:Schema(hidden = true)
   val isValid: Boolean
     get() = StringUtils.isNotBlank(firstName) || StringUtils.isNotBlank(surname) || dateOfBirth != null || StringUtils.isNotBlank(pncNumber) || StringUtils.isNotBlank(crn) ||
       StringUtils.isNotBlank(nomsNumber) || StringUtils.isNotBlank(croNumber)


### PR DESCRIPTION
## Context

In the HMPPS Integration API, we use the OpenAPI specification of the Probation Offender Search to create a simulator for our smoke tests. We noticed it was failing because of the `isValid` property was expected in a request to the `/search` API endpoint. However when manually testing the endpoint in dev, we noticed this isn't actually required.

## Changes proposed in this PR

Hide the `isValid` property in the search request body so it doesn't show up in documentation.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/ministryofjustice/probation-offender-search/assets/42817036/247b3c11-f907-4724-96d8-02136221378d) | ![image](https://github.com/ministryofjustice/probation-offender-search/assets/42817036/311671cb-8d11-4038-a1f9-3c52def1eabd) |