### PR TITLE
PI-1613 Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6
+  hmpps: ministryofjustice/hmpps@7
   mem: circleci/rememborb@0.0.1
   jira: circleci/jira@1.3.1
 
@@ -11,7 +11,8 @@ executors:
     docker:
       - image: cimg/openjdk:17.0
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx4g -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+          JAVA_TOOL_OPTIONS: -Xmx4g -Dorg.gradle.daemon=false
+            -Dkotlin.compiler.execution.strategy=in-process
           TESTCONTAINERS_ELASTICSEARCH_ENABLED: 'false'
       - image: opensearchproject/opensearch:2.5.0
         environment:
@@ -31,7 +32,8 @@ jobs:
       - hmpps/install_aws_cli
       - run:
           name: Wait for ES to be ready
-          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:9200
+          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20
+            --retry-delay 5 http://localhost:9200
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
@@ -59,7 +61,10 @@ jobs:
       name: hmpps/java
       tag: "17.0"
     environment:
-      _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false
+      _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2
+        -XX:ParallelGCThreads=2
+        -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
+        -Dorg.gradle.daemon=false
     parameters:
       image_name:
         type: string
@@ -67,7 +72,9 @@ jobs:
       jira_update:
         type: boolean
         default: false
-        description: When true, updates any referenced Jira tickets with build status. Note that Jira integration must be enabled in your CircleCI project settings.
+        description: When true, updates any referenced Jira tickets with build status.
+          Note that Jira integration must be enabled in your CircleCI project
+          settings.
     steps:
       - checkout
       - run:
@@ -172,4 +179,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-

--- a/helm_deploy/probation-offender-search/Chart.yaml
+++ b/helm_deploy/probation-offender-search/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 dependencies:
   - name: generic-service
-    version: 2.5.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.0

--- a/helm_deploy/probation-offender-search/values.yaml
+++ b/helm_deploy/probation-offender-search/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 generic-service:
   nameOverride: probation-offender-search
@@ -9,7 +8,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/probation-offender-search
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -41,19 +40,14 @@ generic-service:
       OPENSEARCH_URIS: "url"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    delius-aws-1: "52.56.115.146/32"
-    delius-aws-2: "35.178.104.253/32"
-    delius-aws-3: "35.177.47.45/32"
-    analyticplatform-1: "34.250.17.221/32"
-    analyticplatform-2: "34.251.212.33/32"
-    analyticplatform-3: "34.252.4.39/32"
+    delius-prod-1: 52.56.115.146/32
+    delius-prod-2: 35.178.104.253/32
+    delius-prod-3: 35.177.47.45/32
+    analyticplatform-1: 34.250.17.221/32
+    analyticplatform-2: 34.251.212.33/32
+    analyticplatform-3: 34.252.4.39/32
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: probation-offender-search

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Environment specific values, override helm_deploy/probation-offender-search/values.yaml
 
 generic-service:
@@ -12,21 +11,14 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    delius-aws-1: "52.56.240.62/32"
-    delius-aws-2: "18.130.110.168/32"
-    delius-aws-3: "35.178.44.184/32"
-    delius-aws-perf-1: "3.10.200.35/32"
-    delius-aws-perf-2: "3.11.166.247/32"
-    delius-aws-perf-3: "52.56.136.138/32"
-    analyticplatform-1: "34.250.17.221/32"
-    analyticplatform-2: "34.251.212.33/32"
-    analyticplatform-3: "34.252.4.39/32"
+    delius-pre-prod-1: 52.56.240.62/32
+    delius-pre-prod-2: 18.130.110.168/32
+    delius-pre-prod-3: 35.178.44.184/32
+    analyticplatform-1: 34.250.17.221/32
+    analyticplatform-2: 34.251.212.33/32
+    analyticplatform-3: 34.252.4.39/32
+    groups:
+      - internal
 
 cron:
   SYNTHETIC_MONITOR_CRON_EXPRESSION: "*/10 * * * *"


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

2 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/probation-offender-search/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `13 => 6 (7 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi (213.121.161.112/28)
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick (35.177.252.195/32)
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `15 => 9 (6 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- global-protect (35.176.93.186/32)
  

- petty-france-wifi (213.121.161.112/28)
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick (35.177.252.195/32)
  
