### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/probation-offender-search/values.yaml
+++ b/helm_deploy/probation-offender-search/values.yaml
@@ -46,8 +46,8 @@ generic-service:
     analyticplatform-1: 34.250.17.221/32
     analyticplatform-2: 34.251.212.33/32
     analyticplatform-3: 34.252.4.39/32
-    groups:
-      - internal
+    undefined: internal/32
+    groups: []
 
 generic-prometheus-alerts:
   targetApplication: probation-offender-search

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,5 +1,3 @@
-# Environment specific values, override helm_deploy/probation-offender-search/values.yaml
-
 generic-service:
   ingress:
     host: probation-offender-search-preprod.hmpps.service.justice.gov.uk
@@ -17,8 +15,8 @@ generic-service:
     analyticplatform-1: 34.250.17.221/32
     analyticplatform-2: 34.251.212.33/32
     analyticplatform-3: 34.252.4.39/32
-    groups:
-      - internal
+    undefined: internal/32
+    groups: []
 
 cron:
   SYNTHETIC_MONITOR_CRON_EXPRESSION: "*/10 * * * *"


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

2 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/probation-offender-search/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `7 => 7 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `7 => 7 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
