### PR TITLE
PI-2531 Add semantic search model ids for preprod and prod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     OAUTH_ENDPOINT_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk"
     COMMUNITY_ENDPOINT_URL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
     DELIUS_ENDPOINT_URL: "https://probation-search-and-delius-dev.hmpps.service.justice.gov.uk"
+    BEDROCK_MODEL_ID: "p0l8bZABNIF6rA_H6bPt"
     SENTRY_ENVIRONMENT: dev
 
   allowlist:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,7 @@ generic-service:
     OAUTH_ENDPOINT_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk"
     COMMUNITY_ENDPOINT_URL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
     DELIUS_ENDPOINT_URL: "https://probation-search-and-delius-preprod.hmpps.service.justice.gov.uk"
+    BEDROCK_MODEL_ID: "MiEGDpEB-BRJA_2PSmnQ"
     SENTRY_ENVIRONMENT: preprod
 
   allowlist:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     OAUTH_ENDPOINT_URL: "https://sign-in.hmpps.service.justice.gov.uk"
     COMMUNITY_ENDPOINT_URL: "https://community-api-secure.probation.service.justice.gov.uk"
     DELIUS_ENDPOINT_URL: "https://probation-search-and-delius.hmpps.service.justice.gov.uk"
+    BEDROCK_MODEL_ID: "5QoSN5EB-CIfwTDlCJYn"
     SENTRY_ENVIRONMENT: prod
 
   allowlist:

--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearchService.kt
@@ -24,6 +24,7 @@ import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder
 import org.opensearch.search.sort.FieldSortBuilder
 import org.opensearch.search.sort.SortBuilders
 import org.opensearch.search.sort.SortOrder
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -49,12 +50,10 @@ class ContactSearchService(
   private val objectMapper: ObjectMapper,
   private val deliusService: DeliusService,
   private val openSearchClient: OpenSearchClient,
+  @Value("\${bedrock.model.id}") private val bedrockModelId: String // Temp, remove after upgrading to OpenSearch 2.16 - workaround for https://github.com/opensearch-project/OpenSearch/issues/15034
 ) {
 
   private val scope = CoroutineScope(Dispatchers.IO)
-
-  // Temp - workaround for https://github.com/opensearch-project/OpenSearch/issues/15034
-  private val bedrockModelId = "p0l8bZABNIF6rA_H6bPt"
 
   fun keywordSearch(request: ContactSearchRequest, pageable: Pageable): ContactSearchResponse {
     audit(request, pageable)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,4 +72,6 @@ search:
     mapping:
       version: 1
 
+bedrock.model.id: none
+
 sentry.traces-sample-rate: "0.05"


### PR DESCRIPTION
This is only temporary until the fix is available in OpenSearch - we shouldn't need to specify the model id, as we set it as the default here: https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/680133ff4a82c94a23f55ccbd076cde762e6258f/projects/person-search-index-from-delius/container/pipelines/contact/index/search-pipeline.tpl.json#L6