### PR TITLE
PI-2561 Don't include scores by default

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearch.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.probationsearch.contactsearch
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.springframework.data.elasticsearch.annotations.DateFormat
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
@@ -12,8 +13,10 @@ class ContactSearchRequest(
   val crn: String,
   query: String? = "",
   val matchAllTerms: Boolean = true,
+  includeScores: Boolean? = false,
 ) {
   val query = query ?: ""
+  val includeScores: Boolean = includeScores ?: false
 }
 
 data class ContactSearchAuditRequest(
@@ -56,5 +59,6 @@ data class ContactSearchResult(
   @field:Field(type = FieldType.Date, format = [DateFormat.date_hour_minute_second])
   val lastUpdatedDateTime: LocalDateTime,
   val highlights: Map<String, List<String>> = mapOf(),
+  @field:JsonInclude(JsonInclude.Include.NON_NULL)
   val score: Double?,
 )

--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/contactsearch/ContactSearchController.kt
@@ -4,11 +4,7 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/search/contacts")
@@ -18,7 +14,7 @@ class ContactSearchController(val contactSearchService: ContactSearchService) {
   fun searchContact(
     @RequestBody request: ContactSearchRequest,
     @ParameterObject @PageableDefault pageable: Pageable,
-    @RequestParam(defaultValue = "false") semantic: Boolean = false
+    @RequestParam(defaultValue = "false") semantic: Boolean = false,
   ) = if (semantic) {
     contactSearchService.semanticSearch(request, pageable)
   } else {


### PR DESCRIPTION
Otherwise, this breaks Delius:
```
Unrecognized field "score" (class uk.co.bconline.ndelius.dto.contactlog.ContactSearchResultBody), not marked as ignorable
```