### PR TITLE
Bump uk.gov.justice.hmpps.gradle-spring-boot from 7.1.4 to 8.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.14.0")
   implementation("io.opentelemetry:opentelemetry-extension-kotlin")
   testImplementation("org.springframework.security:spring-security-test")
+  testImplementation("org.junit.vintage:junit-vintage-engine")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone:3.0.1")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:4.1.0")
   testImplementation("org.awaitility:awaitility-kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.0.0"
   kotlin("plugin.spring") version "2.1.20"
   id("com.google.cloud.tools.jib") version "3.4.5"
 }


### PR DESCRIPTION
Bumps uk.gov.justice.hmpps.gradle-spring-boot from 7.1.4 to 8.0.0.

---
updated-dependencies:
- dependency-name: uk.gov.justice.hmpps.gradle-spring-boot
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>