### PR TITLE
PI-3476 Add retries to OpenSearch client calls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/utils/Retry.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/probationsearch/utils/Retry.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.hmpps.probationsearch.utils
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+object Retry {
+  fun <T> retry(
+    attempts: Int = 3,
+    delays: List<Long> = listOf(0, 250, 1000, 5000),
+    operation: () -> T,
+  ): T {
+    repeat(attempts) { attempt ->
+      try {
+        return operation()
+      } catch (e: Exception) {
+        if (attempt >= attempts - 1) throw e
+        MILLISECONDS.sleep(delays.getOrElse(attempt - 1) { delays.last() })
+      }
+    }
+    error("Retry error")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/hmpps/probationsearch/utils/RetryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/probationsearch/utils/RetryTest.kt
@@ -1,0 +1,45 @@
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.hmpps.probationsearch.utils.Retry.retry
+
+class RetryTest {
+  @Test
+  fun `should succeed on the first attempt with default settings`() {
+    var attempts = 0
+    val result = retry {
+      attempts++
+      "Success"
+    }
+
+    assertEquals("Success", result)
+    assertEquals(1, attempts)
+  }
+
+  @Test
+  fun `should succeed after two retries (3 total attempts) with default settings`() {
+    var attempts = 0
+    val result = retry {
+      attempts++
+      if (attempts <= 2) error("Failing attempt $attempts")
+      "Success on $attempts"
+    }
+
+    assertEquals("Success on 3", result)
+    assertEquals(3, attempts)
+  }
+
+  @Test
+  fun `should fail and re-throw exception after all default attempts`() {
+    var attempts = 0
+    val finalException = assertThrows<IllegalStateException> {
+      retry {
+        attempts++
+        error("Failing attempt $attempts")
+      }
+    }
+
+    assertEquals(3, attempts)
+    assertEquals("Failing attempt 3", finalException.message)
+  }
+}


### PR DESCRIPTION
To improve resilience when one or more OpenSearch nodes are not responding

The client library does not currently support retries, so I've had to manually wrap the calls in a retry function